### PR TITLE
Added font.css for enabling Segoe UI as ui font

### DIFF
--- a/font.css
+++ b/font.css
@@ -1,0 +1,9 @@
+* {
+	font-family: "Segoe UI Display", "Segoe UI"; /* Segoe UI is the standard Windows 10/11 font */
+	font: "Segoe UI Display", "Segoe UI";
+	font-size: 1.3rem; /* size may depend on screen resolution and scale settings, also on personal opinion */
+}
+toolbar { /* needed for the minimize, maximize and close button to work */
+	font-size: 1rem !important; /* may also depend on resolution and scaling */
+	font-family: system-font, sans-serif !important; /* important, with Segoe UI the symbols won't be displayed correctly */
+}

--- a/userChrome.css
+++ b/userChrome.css
@@ -49,5 +49,8 @@ mimic Microsoft Edge and several community userChromes.
 @import url("./animations.css") -moz-pref("uc.tweak.enable-nebula-animations");
 @import url("./pip.css") -moz-pref("uc.tweak.pip");
 
+/* custom font */
+@import url("./font.css");
+
 /* your personal custom css */
 @import url("./custom.css");


### PR DESCRIPTION
The Firefox font doesn't match the Windows ui font (and personally I hate the default font). So I've added Segoe UI Display as font in the font.css.
The window buttons won't get displayed with Segoe UI so I add a custom toolbar style to make them use the default Firefox font.